### PR TITLE
fix: use stored longitude for map URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1419,7 +1419,7 @@
                     selectedPlaceDetails.address = `Coordenadas: ${latLng.lat().toFixed(4)}, ${latLng.lng().toFixed(4)}`;
                     selectedPlaceDetails.lat = latLng.lat();
                     selectedPlaceDetails.lng = latLng.lng();
-                    selectedPlaceDetails.googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${selectedPlaceDetails.lat},${latLng.lng()}`;
+                    selectedPlaceDetails.googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${selectedPlaceDetails.lat},${selectedPlaceDetails.lng}`;
                     console.warn('Nenhum endereço encontrado para as coordenadas selecionadas, usando lat/lng.');
                 }
             });


### PR DESCRIPTION
## Summary
- replace temporary longitude reference with stored value when building the Google Maps URL in `placeMarkerAndPanTo`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876b4fb7c5883329cc9f07837a40a64