### PR TITLE
test: cover formatCurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Harmonia do Altar
+
+This project contains the web page for the wedding band.
+
+## Testing
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```
+
+The tests cover helper utilities such as `formatCurrency`.

--- a/formatCurrency.js
+++ b/formatCurrency.js
@@ -1,0 +1,6 @@
+function formatCurrency(value) {
+    if (typeof value !== 'number' || isNaN(value)) return 'R$ 0,00';
+    return `R$ ${value.toFixed(2).replace('.', ',')}`;
+}
+
+module.exports = formatCurrency;

--- a/formatCurrency.test.js
+++ b/formatCurrency.test.js
@@ -1,0 +1,15 @@
+const formatCurrency = require('./formatCurrency');
+
+describe('formatCurrency', () => {
+  test('formats positive numbers correctly', () => {
+    expect(formatCurrency(0)).toBe('R$ 0,00');
+    expect(formatCurrency(1234.56)).toBe('R$ 1234,56');
+    expect(formatCurrency(10)).toBe('R$ 10,00');
+  });
+
+  test('returns placeholder for invalid inputs', () => {
+    expect(formatCurrency(NaN)).toBe('R$ 0,00');
+    expect(formatCurrency('123')).toBe('R$ 0,00');
+    expect(formatCurrency(undefined)).toBe('R$ 0,00');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "harmonia-do-altar",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest boilerplate
- cover `formatCurrency` helper with unit tests
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b4fa21ac8332946ac397d2850809